### PR TITLE
#152638428 Improve UX when a user wants to create a group

### DIFF
--- a/client/js/components/containers/NewGroup.jsx
+++ b/client/js/components/containers/NewGroup.jsx
@@ -63,7 +63,7 @@ export class NewGroup extends React.Component {
   onCreateGroup(event) {
     event.preventDefault();
     if (this.state.name === '') {
-      this.setState({ error: 'Error: One or more fields are empty' });
+      this.setState({ errorMessage: 'Group name is required' });
       return;
     }
     if (this.state.name.length > 20) {


### PR DESCRIPTION
#### What does this PR do?
Add error message when no group name is given and create button is clicked when creating a new group
#### Description of task to be completed?
When a user clicks on "create" without filling in the group name, display an error letting the user know that the group name is required.
#### What are the relevant Pivotal tracker stories?
#152638428